### PR TITLE
Fixed parent node query selector for new events page layout and null parsed comic stopping progress.

### DIFF
--- a/src/MarvelComicCollection.ts
+++ b/src/MarvelComicCollection.ts
@@ -29,7 +29,7 @@ export default class MarvelComicCollection {
                     .then(() => onComicAdded(this.comics[i]))
                     .catch(() => onError(this.comics[i]))
                     .finally(() => always(this.comics[i]))
-            )
+            )            
         }
         return Promise.all(promises)
     }
@@ -72,7 +72,10 @@ export default class MarvelComicCollection {
             tmpNode.innerHTML = coreIssueDOM + tieIssueDOM
             const comicNodes = tmpNode.getElementsByClassName('row-item-image')
             for (let i = 0; i < comicNodes.length; i++) {
-                comics.push(MarvelComic.initFromHtml(comicNodes[i] as HTMLElement))
+                var comic = MarvelComic.initFromHtml(comicNodes[i] as HTMLElement);
+                if (comic != null) {
+                    comics.push(comic)
+                }
             }
             return new MarvelComicCollection(comics, 'event', eventId)
         })
@@ -93,7 +96,10 @@ export default class MarvelComicCollection {
                 tmpNode.innerHTML = issuesDOM.output
                 const comicsNodes = tmpNode.getElementsByClassName('row-item-image')
                 for (let i = 0; i < comicsNodes.length; i++) {
-                    comics.push(MarvelComic.initFromHtml(comicsNodes[i] as HTMLElement))
+                    var comic = MarvelComic.initFromHtml(comicsNodes[i] as HTMLElement);
+                    if (comic != null) {
+                        comics.push(comic)
+                    }
                 }
                 return new MarvelComicCollection(comics, 'series', seriesId)
             })

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ let id = parseInt(match[1])
 const template = document.createElement('div')
 template.innerHTML = templateHtml
 const parentNode = document.querySelector(pageType === PageType.events
-        ? '#comics-eventsdetail > div.header-box.grid-container > div > div.details-right'
+        ? '#page-content .grid-container .details-right'
         : '.module .featured-item-info-wrap .featured-item-text'
     )
 parentNode.append(template)


### PR DESCRIPTION
The events page seems to have changed layout since this was coded. The query selector was returning null, so I simply updated it to find the correct element again. Tested and functional!